### PR TITLE
Optimize download logging

### DIFF
--- a/docs/DOCUMENTACAO.md
+++ b/docs/DOCUMENTACAO.md
@@ -193,7 +193,7 @@ def generate_filename(message, topic_name: str = None) -> str
 
 #### `write_download_log()` - Logging
 ```python
-def write_download_log(log_file_path: str, filename: str, media_type: str, message_id: int, message_date, topic_name: str = None)
+def write_download_log(log_file, filename: str, media_type: str, message_id: int, message_date, topic_name: str = None)
 ```
 **Funcionalidade**: Registra operações de download
 **Formato do Log**: `timestamp: filename - media_type - Msg ID: id - Data: date - Tópico: topic`

--- a/file_utils.py
+++ b/file_utils.py
@@ -158,7 +158,7 @@ def generate_filename(message, topic_name: str = None) -> str:
 
 
 def write_download_log(
-    log_file_path: str,
+    log_file,
     filename: str,
     media_type: str,
     message_id: int,
@@ -169,7 +169,7 @@ def write_download_log(
     Write download operation to log file
 
     Args:
-        log_file_path: Path to the log file
+        log_file: Open file handle to append log entries
         filename: Downloaded filename
         media_type: Type of media downloaded
         message_id: Telegram message ID
@@ -184,8 +184,7 @@ def write_download_log(
         f"Msg ID: {message_id} - Data: {message_date}{topic_info}\n"
     )
 
-    with open(log_file_path, "a", encoding="utf-8") as log:
-        log.write(log_entry)
+    log_file.write(log_entry)
 
 
 def format_file_size(size_bytes: int) -> str:


### PR DESCRIPTION
## Summary
- write download log entries to an already-open handle
- open `download_log.txt` once per chat in the organizer
- document new `write_download_log` signature

## Testing
- `python3 test_setup.py` *(fails: telethon, tqdm and qrcode missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847341c8910832c886fbb6066d8c513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved log writing performance by reducing repeated file open/close operations during media export.
- **Documentation**
	- Updated documentation to clarify the revised usage of the log writing function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->