### PR TITLE
Implement file size limit and concurrent downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ exports/
 ```python
 # 📊 Limites e Performance
 DEFAULT_LIMIT_PER_CHAT = 1000        # Mensagens por chat
-MAX_FILE_SIZE = 1024 * 1024 * 1024   # Limite: 1GB por arquivo
-CONCURRENT_DOWNLOADS = 1              # Downloads simultâneos
+MAX_FILE_SIZE = 1024 * 1024 * 1024   # Limite: 1GB por arquivo (acima disso será ignorado)
+CONCURRENT_DOWNLOADS = 1              # Downloads simultâneos (usando semáforo)
 
 # 📱 Tipos de mídia suportados
 SUPPORTED_MEDIA_TYPES = [
@@ -231,7 +231,7 @@ SUPPORTED_MEDIA_TYPES = [
 | Limitação | Impacto | Solução |
 |-----------|---------|---------|
 | Rate limits do Telegram | Delays automáticos | Aguarda tempo especificado |
-| Arquivos muito grandes | Download lento | Configurable em `MAX_FILE_SIZE` |
+| Arquivos muito grandes | Ignorados acima do limite | Configurável em `MAX_FILE_SIZE` |
 | Chats privados restritos | Alguns inacessíveis | Múltiplas tentativas automáticas |
 | Espaço em disco | Pode esgotar | Monitore espaço disponível |
 

--- a/docs/DOCUMENTACAO.md
+++ b/docs/DOCUMENTACAO.md
@@ -209,8 +209,8 @@ API_HASH = '0123456789abcdef0123456789abcdef'  # Seu API Hash
 #### Parâmetros de Download
 ```python
 DEFAULT_LIMIT_PER_CHAT = 1000  # Mensagens por chat
-MAX_FILE_SIZE = 1024 * 1024 * 1024  # 1GB limite
-CONCURRENT_DOWNLOADS = 1  # Downloads simultâneos
+MAX_FILE_SIZE = 1024 * 1024 * 1024  # 1GB limite (arquivos maiores são ignorados)
+CONCURRENT_DOWNLOADS = 1  # Downloads simultâneos controlados por semáforo
 ```
 
 #### Mapeamento de Diretórios
@@ -461,8 +461,8 @@ entity = await client.get_entity(peer)
 ```python
 # config.py
 DEFAULT_LIMIT_PER_CHAT = 1000        # Mensagens por chat
-MAX_FILE_SIZE = 1024 * 1024 * 1024   # 1GB limite
-CONCURRENT_DOWNLOADS = 1              # Downloads simultâneos
+MAX_FILE_SIZE = 1024 * 1024 * 1024   # 1GB limite (acima disso é pulado)
+CONCURRENT_DOWNLOADS = 1              # Downloads simultâneos via Semaphore
 ```
 
 #### Seleção de Tipos de Mídia
@@ -493,12 +493,8 @@ async for message in client.iter_messages(chat_entity, offset_date=start_date):
 ```
 
 #### Por Tamanho de Arquivo
-```python
-# Verificar tamanho antes do download
-if hasattr(message.document, 'size') and message.document.size > MAX_FILE_SIZE:
-    print(f"Arquivo muito grande: {message.document.size} bytes")
-    continue
-```
+O verificador de tamanho agora é padrão. Arquivos com tamanho acima de
+`MAX_FILE_SIZE` são automaticamente ignorados durante o download.
 
 ---
 

--- a/telethon_handlers.py
+++ b/telethon_handlers.py
@@ -16,7 +16,14 @@ from telethon.tl.types import Channel, InputPeerEmpty
 from qrcode import QRCode
 from tqdm import tqdm
 
-from config import API_ID, API_HASH, SESSION_NAME, EXPORTS_DIR
+from config import (
+    API_ID,
+    API_HASH,
+    SESSION_NAME,
+    EXPORTS_DIR,
+    MAX_FILE_SIZE,
+    CONCURRENT_DOWNLOADS,
+)
 from file_utils import (
     sanitize_filename,
     create_media_directories,
@@ -251,6 +258,10 @@ async def export_media_organized(
     topic_counts = {}
     processed_count = 0
 
+    # Semaphore for concurrent downloads
+    semaphore = asyncio.Semaphore(CONCURRENT_DOWNLOADS)
+    download_tasks = []
+
     print(f"📁 Estrutura de diretórios criada em: {base_dir}")
     if is_forum:
         print(f"📂 Grupo com tópicos detectado - {len(topics)} tópicos organizados")
@@ -300,25 +311,50 @@ async def export_media_organized(
             filename = generate_filename(message, topic_name)
             filepath = os.path.join(target_dir, filename)
 
-            # Download the file
-            print(f"📥 Baixando: {filename}")
-            await client.download_media(message, file=filepath)
+            # Skip if document size exceeds limit
+            if (
+                hasattr(message, "document")
+                and hasattr(message.document, "size")
+                and message.document.size
+                and message.document.size > MAX_FILE_SIZE
+            ):
+                size_str = format_file_size(message.document.size)
+                print(
+                    f"⚠️ Tamanho excede o limite ({size_str}). Pulando {filename}"
+                )
+                continue
 
-            # Log the operation
-            write_download_log(
-                log_file, filename, media_type, message.id, message.date, topic_name
-            )
+            async def download_and_log():
+                async with semaphore:
+                    print(f"📥 Baixando: {filename}")
+                    await client.download_media(message, file=filepath)
+                write_download_log(
+                    log_file,
+                    filename,
+                    media_type,
+                    message.id,
+                    message.date,
+                    topic_name,
+                )
+                return topic_name
 
-            downloaded_count += 1
-            if topic_name:
-                topic_counts[topic_name] += 1
+            download_tasks.append(asyncio.create_task(download_and_log()))
 
         except Exception as e:
             print(f"❌ Erro ao baixar mídia da mensagem {message.id}: {e}")
             continue
 
-    # Close progress bar
+    # Close progress bar and wait for downloads
     pbar.close()
+
+    results = await asyncio.gather(*download_tasks, return_exceptions=True)
+    for res in results:
+        if isinstance(res, Exception):
+            print(f"❌ Erro em tarefa de download: {res}")
+            continue
+        downloaded_count += 1
+        if res:
+            topic_counts[res] += 1
 
     # Final report
     print(f"\n✅ Download concluído!")


### PR DESCRIPTION
## Summary
- skip downloads over `MAX_FILE_SIZE`
- add semaphore-limited concurrent downloads
- document limits and concurrency behavior

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6847341c241c832caf5b40aea0973e7f