### PR TITLE
Add max_attempts to QR login

### DIFF
--- a/docs/DOCUMENTACAO.md
+++ b/docs/DOCUMENTACAO.md
@@ -92,7 +92,7 @@ O **Telegram Media Downloader** é uma ferramenta automatizada desenvolvida em P
 
 #### `login_with_qr()` - Autenticação
 ```python
-async def login_with_qr() -> TelegramClient
+async def login_with_qr(max_attempts: int = 5) -> Optional[TelegramClient]
 ```
 **Funcionalidade**: Realiza login via QR Code com suporte a 2FA
 **Retorna**: Cliente Telegram autenticado

--- a/docs/telegram-telethon-doc.md
+++ b/docs/telegram-telethon-doc.md
@@ -64,7 +64,7 @@ def display_url_as_qr(url):
     print(f"URL do QR Code: {url}")
     gen_qr(url)
 
-async def login_with_qr():
+async def login_with_qr(max_attempts: int = 5):
     """
     Realiza login via QR Code com tratamento de erros
     Retorna cliente autenticado
@@ -78,7 +78,8 @@ async def login_with_qr():
     print("Cliente conectado:", client.is_connected())
     
     authenticated = False
-    while not authenticated:
+    attempt = 1
+    while not authenticated and attempt <= max_attempts:
         display_url_as_qr(qr_login.url)
         print("Escaneie o QR Code com seu Telegram...")
         
@@ -87,12 +88,20 @@ async def login_with_qr():
         except TimeoutError:
             print("QR Code expirou, gerando novo...")
             await qr_login.recreate()
+            attempt += 1
         except Exception as e:
             if "SessionPasswordNeededError" in str(e):
                 password = input("Digite sua senha 2FA: ")
                 await client.sign_in(password=password)
                 authenticated = True
-    
+            else:
+                print(f"Erro durante login: {e}")
+                attempt += 1
+
+    if not authenticated:
+        print("Falha no login por QR Code")
+        return None
+
     print("Login realizado com sucesso!")
     return client
 ```


### PR DESCRIPTION
## Summary
- allow setting a maximum number of QR login attempts
- document the new `max_attempts` parameter in both docs

## Testing
- `python3 test_setup.py` *(fails: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_6847341d7e2c832cb7b6d6d373a16543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect changes in the QR code login process, including the addition of a configurable maximum number of login attempts and updated function behavior.

- **New Features**
  - QR code login now supports setting a maximum number of attempts, with feedback if authentication fails after all attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->